### PR TITLE
Add logistic map mask generator

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,7 +1,27 @@
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
+/// Parameter for the logistic map used when generating chaotic masks
+pub const LOGISTIC_R: f64 = 3.99;
+
+/// Generate a chaotic byte mask using the logistic map `x_{n+1} = r*x_n*(1-x_n)`.
+///
+/// The seed is used to initialise `x_0` by normalising it to the range (0,1).
+pub fn logistic_mask(seed: u64, size: usize, r: f64) -> Vec<u8> {
+    let mut x = (seed as f64) / (u64::MAX as f64);
+    let mut out = Vec::with_capacity(size);
+    for _ in 0..size {
+        x = r * x * (1.0 - x);
+        // scale to byte range
+        out.push((x * 255.0) as u8);
+    }
+    out
+}
+
 pub fn generate_mask(seed: u64, size: usize) -> Vec<u8> {
+    if seed == LOGISTIC_SEED {
+        return logistic_mask(seed, size, LOGISTIC_R);
+    }
     let mut rng = StdRng::seed_from_u64(seed);
     (0..size).map(|_| rng.gen::<u8>()).collect()
 }
@@ -9,3 +29,23 @@ pub fn generate_mask(seed: u64, size: usize) -> Vec<u8> {
 pub const PI_SEED: u64 = 3141592653;
 pub const PHI_SEED: u64 = 1618033988;
 pub const LOGISTIC_SEED: u64 = 2718281828;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logistic_mask_deterministic() {
+        let mask1 = logistic_mask(12345, 16, LOGISTIC_R);
+        let mask2 = logistic_mask(12345, 16, LOGISTIC_R);
+        assert_eq!(mask1, mask2);
+    }
+
+    #[test]
+    fn generate_mask_with_logistic_seed() {
+        let mask1 = generate_mask(LOGISTIC_SEED, 16);
+        let mask2 = generate_mask(LOGISTIC_SEED, 16);
+        assert_eq!(mask1, mask2);
+        assert_eq!(mask1, logistic_mask(LOGISTIC_SEED, 16, LOGISTIC_R));
+    }
+}

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -1,4 +1,6 @@
-use crate::constants::{generate_mask, LOGISTIC_SEED, PHI_SEED, PI_SEED};
+use crate::constants::{
+    generate_mask, logistic_mask, LOGISTIC_R, LOGISTIC_SEED, PHI_SEED, PI_SEED,
+};
 use crc32fast::Hasher;
 use std::convert::TryInto;
 
@@ -8,7 +10,7 @@ pub fn compress_data(input: &[u8]) -> Vec<u8> {
     let size = input.len();
     let pi_mask = generate_mask(PI_SEED, size);
     let phi_mask = generate_mask(PHI_SEED, size);
-    let logistic_mask = generate_mask(LOGISTIC_SEED, size);
+    let logistic_mask = logistic_mask(LOGISTIC_SEED, size, LOGISTIC_R);
 
     let mut output = input.to_vec();
 
@@ -118,7 +120,7 @@ pub fn decompress_data(input: &[u8]) -> Vec<u8> {
     let size = original_size as usize;
     let pi_mask = generate_mask(PI_SEED, size);
     let phi_mask = generate_mask(PHI_SEED, size);
-    let logistic_mask = generate_mask(LOGISTIC_SEED, size);
+    let logistic_mask = logistic_mask(LOGISTIC_SEED, size, LOGISTIC_R);
 
     let mut output = compressed_data.to_vec();
 
@@ -188,7 +190,7 @@ pub fn repair_data(input: &[u8]) -> (Vec<u8>, bool) {
 
     let pi_mask = generate_mask(PI_SEED, original_size);
     let phi_mask = generate_mask(PHI_SEED, original_size);
-    let logistic_mask = generate_mask(LOGISTIC_SEED, original_size);
+    let logistic_mask = logistic_mask(LOGISTIC_SEED, original_size, LOGISTIC_R);
 
     let mut output = padded;
 


### PR DESCRIPTION
## Summary
- generate chaotic byte masks using logistic map
- use logistic mask in ratchet functions
- verify logistic mask determinism in unit tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684258b4ac008330b1df5b84df895497