### PR TITLE
Switch SGIL header

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ChaosRegen mechanically extracts entropy from random data using
 universal constants, modular mathematics, and reversible transforms.
 
 Now includes:
-- Magic file headers
+- SGIL magic file headers
 - Original file size tracking
 - CRC32 checksum verification
 - Recursive microzone passes (up to three) with entropy sensing

--- a/SigilProtocol.md
+++ b/SigilProtocol.md
@@ -47,10 +47,10 @@ Sigil's `.sg1` format includes self-verifying structures that make it suitable f
 
 ### How It Works
 
-1. **Magic Header (`CRGN`)**
+1. **Magic Header (`SGIL`)**
    - Identifies the file format
    - Prevents filetype spoofing or trick execution
-   - Retained from ChaosRegen for compatibility (may evolve to `SGIL`)
+   - Supersedes the old `CRGN` header used in early prototypes
 
 2. **Original File Length**  
    - Encoded in the header  

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -10,7 +10,10 @@ const MAX_PASSES: usize = 3;
 const ENTROPY_THRESHOLD: f64 = 0.1; // bits per byte
 const PRIMES: [u16; 3] = [251, 241, 239];
 
-const MAGIC: &[u8; 4] = b"CRGN";
+/// Magic header used in `.sg1` files.
+///
+/// `SGIL` is short for "Sigil", superseding the previous `CRGN` header.
+const MAGIC: &[u8; 4] = b"SGIL";
 
 pub fn compress_data(input: &[u8]) -> Vec<u8> {
     let size = input.len();


### PR DESCRIPTION
## Summary
- use `SGIL` magic header in ratchet implementation
- update README to mention the new magic header
- document the new header in SigilProtocol

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68425be3890c833089a610e371b7ab97